### PR TITLE
Put dockerui in the PATH in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get upgrade
 
 ADD . /app/
-RUN ln -s /app/dockerui /dockerui
+RUN ln -s /app/dockerui /bin/dockerui
 
 EXPOSE 9000
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ DockerUI is a web interface to interact with the Remote API.  The goal is to pro
 This is the easiest way to run DockerUI.  To run the container make sure you have dockerd running with the -H option so that the remote api can be accessed via ip and not bound to localhost.  After you pull the container you need to run it with your dockerd ip as an argument to the dockerui command.
 
 
-    docker run -d crosbymichael/dockerui /dockerui -e="http://192.168.1.9:4243"
+    docker run -d crosbymichael/dockerui dockerui -e="http://192.168.1.9:4243"
 
 This tells dockerui to use http://192.168.1.9:4243 to communicate to dockerd's Remote API.
 


### PR DESCRIPTION
This seems a cleaner way to start the daemon.

Even better would be if the daemon had a sensible default for the docker address, it could then be added as a CMD in the Dockerfile. It seems that the docker0 bridge's address is 172.16.42.1, if docker binds on that IP address then we could default to "-e="http://172.16.42.1:4243""
