### PR TITLE
display PortMapping as opposed to PortSpec.

### DIFF
--- a/partials/container.html
+++ b/partials/container.html
@@ -24,7 +24,10 @@
             </tr>
             <tr>
                 <td>Ports:</td>
-                <td>{{ container.NetworkSettings.PortMapping }}</td>
+                <td>
+                    {{  container.NetworkSettings.PortMapping ||   container.Config.PortSpecs     }}
+                </td>
+
             </tr>
             <tr>
                 <td>Hostname:</td>


### PR DESCRIPTION
PortsSpec only display the ports, displaying PortMapping is more convenient.
