### PR TITLE
Expose ExposedPorts and PublishAllPorts for containers

### DIFF
--- a/partials/container.html
+++ b/partials/container.html
@@ -23,9 +23,21 @@
                 <td>{{ container.Args }}</td>
             </tr>
             <tr>
+                <td>Exposed Ports:</td>
+                <td>
+                    <ul>
+                        <li ng-repeat="(k, v) in container.Config.ExposedPorts">{{ k }}</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>Publish All:</td>
+                <td>{{ container.HostConfig.PublishAllPorts }}</td>
+            </tr>
+            <tr>
                 <td>Ports:</td>
                 <td>
-                    {{  container.NetworkSettings.PortMapping ||   container.Config.PortSpecs     }}
+                    {{ container.NetworkSettings.PortMapping || container.Config.PortSpecs }}
                 </td>
 
             </tr>


### PR DESCRIPTION
Not the prettiest way to expose port information, but I was getting really confused when looking at my containers with ExposedPorts and PublishAllPorts set and seeing nothing.
