### PR TITLE
Add Microbox build for dockerui (reduced to 16MB size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ DockerUI is a web interface to interact with the Remote API.  The goal is to pro
 * `docker run -d -p 9000:9000 -v /var/run/docker.sock:/docker.sock crosbymichael/dockerui -e /docker.sock`
 * Open your browser to `http://<dockerd host ip>:9000`
 
+* Or use Microbox build (only 16MB size) `docker run -d -p 9000:9000 -v /var/run/docker.sock:/docker.sock microbox/dockerui`
 
 Bind mounting the unix socket into the dockerui container is much more secure than exposing your docker 
 daemon over tcp.  You should still secure your dockerui instance behind some type of auth.  Maybe running 


### PR DESCRIPTION
Currently dockerui image size is about 398MB. I manually removed all unnecessary files and reduce the size of the image to 16MB only.

You can verify from `docker pull microbox/dockerui:latest`. This build based on latest `crosbymichael/dockerui` image.