### PR TITLE
Fixing navbar rendering issue on Firefox.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -46,6 +46,7 @@ body {
 
 .navbar .nav {
     margin: 0;
+    width: 100%;
 }
 
 .navbar .nav li {


### PR DESCRIPTION
I noticed that DockerUI has rendering problems when loaded in Firefox 33 when compared with Chrome 39. As you can see in the first image below, the `navbar` element has its cells misaligned and not evenly distributed.
![screen shot 2014-11-27 at 3 16 47 pm](https://cloud.githubusercontent.com/assets/1198068/5220364/007d0580-764b-11e4-8574-faebf4396a23.png)
In order to fix this issue, I explicit added the `width` valued to 100% to the element. The result is in the following image:
![screen shot 2014-11-27 at 3 16 57 pm](https://cloud.githubusercontent.com/assets/1198068/5220365/01d48868-764b-11e4-9c3b-707931201700.png)
