### PR TITLE
Fix of HostConfig being lost when starting containers from the list

### DIFF
--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -26,15 +26,41 @@ function($scope, Container, Settings, Messages, ViewSpinner) {
         };
         angular.forEach(items, function(c) {
             if (c.Checked) {
-                counter = counter + 1;
-                action({id: c.Id, HostConfig: c.HostConfig}, function(d) {
-                    Messages.send("Container " + msg, c.Id);
-                    var index = $scope.containers.indexOf(c);
-                    complete();
-                }, function(e) {
-                    Messages.error("Failure", e.data);
-                    complete();
-                });
+              if(msg === "Started"){
+                  Container.get({id: c.Id}, function(d) {
+                    c = d;
+                    counter = counter + 1;
+                    action({id: c.Id, HostConfig: c.HostConfig || {}}, function(d) {
+                        Messages.send("Container " + msg, c.Id);
+                        var index = $scope.containers.indexOf(c);
+                        complete();
+                    }, function(e) {
+                        Messages.error("Failure", e.data);
+                        complete();
+                    });
+                  }, function(e) {
+                      if (e.status === 404) {
+                          $('.detail').hide();
+                          Messages.error("Not found", "Container not found.");
+                      } else {
+                          Messages.error("Failure", e.data);
+                      }
+                      complete();
+                  });
+                }
+                else{
+                  counter = counter + 1;
+                  action({id: c.Id}, function(d) {
+                      Messages.send("Container " + msg, c.Id);
+                      var index = $scope.containers.indexOf(c);
+                      complete();
+                  }, function(e) {
+                      Messages.error("Failure", e.data);
+                      complete();
+                  });
+
+                }
+
             }
         });
         if (counter === 0) {

--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -27,7 +27,7 @@ function($scope, Container, Settings, Messages, ViewSpinner) {
         angular.forEach(items, function(c) {
             if (c.Checked) {
                 counter = counter + 1;
-                action({id: c.Id}, function(d) {
+                action({id: c.Id, HostConfig: c.HostConfig}, function(d) {
                     Messages.send("Container " + msg, c.Id);
                     var index = $scope.containers.indexOf(c);
                     complete();

--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -26,7 +26,7 @@ function($scope, Container, Settings, Messages, ViewSpinner) {
         };
         angular.forEach(items, function(c) {
             if (c.Checked) {
-              if(msg === "Started"){
+              if(action === Container.start){
                   Container.get({id: c.Id}, function(d) {
                     c = d;
                     counter = counter + 1;

--- a/dist/dockerui.js
+++ b/dist/dockerui.js
@@ -1,4 +1,4 @@
-/*! dockerui - v0.6.0 - 2015-02-01
+/*! dockerui - v0.6.0 - 2015-02-08
  * https://github.com/crosbymichael/dockerui
  * Copyright (c) 2015 Michael Crosby & Kevan Ahlquist;
  * Licensed MIT
@@ -211,15 +211,41 @@ function($scope, Container, Settings, Messages, ViewSpinner) {
         };
         angular.forEach(items, function(c) {
             if (c.Checked) {
-                counter = counter + 1;
-                action({id: c.Id}, function(d) {
-                    Messages.send("Container " + msg, c.Id);
-                    var index = $scope.containers.indexOf(c);
-                    complete();
-                }, function(e) {
-                    Messages.error("Failure", e.data);
-                    complete();
-                });
+              if(msg === "Started"){
+                  Container.get({id: c.Id}, function(d) {
+                    c = d;
+                    counter = counter + 1;
+                    action({id: c.Id, HostConfig: c.HostConfig || {}}, function(d) {
+                        Messages.send("Container " + msg, c.Id);
+                        var index = $scope.containers.indexOf(c);
+                        complete();
+                    }, function(e) {
+                        Messages.error("Failure", e.data);
+                        complete();
+                    });
+                  }, function(e) {
+                      if (e.status === 404) {
+                          $('.detail').hide();
+                          Messages.error("Not found", "Container not found.");
+                      } else {
+                          Messages.error("Failure", e.data);
+                      }
+                      complete();
+                  });
+                }
+                else{
+                  counter = counter + 1;
+                  action({id: c.Id}, function(d) {
+                      Messages.send("Container " + msg, c.Id);
+                      var index = $scope.containers.indexOf(c);
+                      complete();
+                  }, function(e) {
+                      Messages.error("Failure", e.data);
+                      complete();
+                  });
+
+                }
+
             }
         });
         if (counter === 0) {

--- a/dist/dockerui.js
+++ b/dist/dockerui.js
@@ -1,4 +1,4 @@
-/*! dockerui - v0.6.0 - 2015-02-08
+/*! dockerui - v0.6.0 - 2015-02-09
  * https://github.com/crosbymichael/dockerui
  * Copyright (c) 2015 Michael Crosby & Kevan Ahlquist;
  * Licensed MIT
@@ -211,7 +211,7 @@ function($scope, Container, Settings, Messages, ViewSpinner) {
         };
         angular.forEach(items, function(c) {
             if (c.Checked) {
-              if(msg === "Started"){
+              if(action === Container.start){
                   Container.get({id: c.Id}, function(d) {
                     c = d;
                     counter = counter + 1;


### PR DESCRIPTION
fix for #78

Checks whether a container is being started and fetches it's config before starting
Tested on Docker 1.4.1