### PR TITLE
Use centurylink/golang-builder to build tiny docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM crosbymichael/golang
+FROM scratch
 
-COPY dockerui.go /app/
-COPY dist/ /app/
-WORKDIR /app/
-RUN go build dockerui.go
+COPY dockerui /
+COPY dist /
+
 EXPOSE 9000
-ENTRYPOINT ["./dockerui"]
+ENTRYPOINT ["/dockerui"]

--- a/dockerui.go
+++ b/dockerui.go
@@ -1,4 +1,4 @@
-package main
+package main // import "github.com/crosbymichael/dockerui"
 
 import (
 	"flag"


### PR DESCRIPTION
Resulting image is 5.4MB, significantly smaller than even microbox's dockerui image at 16.75MB.

Command I used to build [example image](https://registry.hub.docker.com/u/tehbilly/dockerui/):

```bash
$ docker run --rm -v $(pwd):/src -v /var/run/docker.sock:/var/run/docker.sock centurylink/golang-builder tehbilly/dockerui:latest
```

Omit the last argument to have it be tagged based on project name, or change to whatever you'd like. Feel free to `docker pull tehbilly/dockerui` and examine the image it builds.