### PR TITLE
Switch to using gliderlabs/alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gliderlabs/alpine:3.1
 
 COPY dockerui /
 COPY dist /


### PR DESCRIPTION
Using scratch as a baseimage is bad because of the PID 1 zombie reaping problem. See https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem for more details on it.
gliderlabs/alpine is a great solution for this, as it is based on Alpine Linux, is only 5 megabytes, and has a full featured init process.