### PR TITLE
Restart Feature - Implementing restart feature for single containers

### DIFF
--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -2,7 +2,7 @@ angular.module('dockerui.services', ['ngResource'])
     .factory('Container', function ($resource, Settings) {
         'use strict';
         // Resource for interacting with the docker containers
-        // https://docs.docker.com/reference/api/docker_remote_api/
+        // http://docs.docker.io/en/latest/api/docker_remote_api.html#containers
         return $resource(Settings.url + '/containers/:id/:action', {
             name: '@name'
         }, {

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -2,7 +2,7 @@ angular.module('dockerui.services', ['ngResource'])
     .factory('Container', function ($resource, Settings) {
         'use strict';
         // Resource for interacting with the docker containers
-        // http://docs.docker.io/en/latest/api/docker_remote_api.html#containers
+        // https://docs.docker.com/reference/api/docker_remote_api/
         return $resource(Settings.url + '/containers/:id/:action', {
             name: '@name'
         }, {


### PR DESCRIPTION
I am adding the restart feature for single containers.  Potentially lost during a merge.  

Does not show when container is stopped.  The restart button only displays if the container is active.  Unit test will be added to match development.  Have to pair to determine current unit test commands.