### PR TITLE
Adding protocol select menu in portBinding during container creation

### DIFF
--- a/app/components/startContainer/startContainerController.js
+++ b/app/components/startContainer/startContainerController.js
@@ -83,6 +83,9 @@ function($scope, $routeParams, $location, Container, Messages, containernameFilt
         var PortBindings = {};
         config.HostConfig.PortBindings.forEach(function(portBinding) {
             var intPort = portBinding.intPort + "/tcp";
+            if (portBinding.protocol === "udp") {
+                intPort = portBinding.intPort + "/udp";
+            }
             var binding = {
                 HostIp: portBinding.ip,
                 HostPort: portBinding.extPort

--- a/app/components/startContainer/startcontainer.html
+++ b/app/components/startContainer/startcontainer.html
@@ -289,6 +289,10 @@
                                         <input type="text" ng-model="portBinding.extPort" class="form-control" placeholder="Host Port"/>
                                         <label class="sr-only">Container port:</label>
                                         <input type="text" ng-model="portBinding.intPort" class="form-control" placeholder="Container Port"/>
+                                        <select ng-model="portBinding.protocol">
+                                            <option value="">tcp</option>
+                                            <option value="udp">udp</option>
+                                        </select>
                                         <button class="btn btn-danger btn-xs form-control" ng-click="rmEntry(config.HostConfig.PortBindings, portBinding)">Remove</button>
                                     </div>
                                 </div>


### PR DESCRIPTION
During the creation of one container, I needed to bind an UDP port and I saw that DockerUI hadn't got the option to select the desired protocol in the portBinding field, so I added it during the startContainer flow.

I'm not sure if this is the proper way to add this feature (first time writting Javascript and doing a pull request).

I hope it helps.