### PR TITLE
Use NetworkSettings.Ports rather than HostConfig.PortBindings

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -106,7 +106,7 @@
             <td>Ports:</td>
             <td>
                 <ul style="display:inline-table">
-                    <li ng-repeat="(containerport, hostports) in container.HostConfig.PortBindings">
+                    <li ng-repeat="(containerport, hostports) in container.NetworkSettings.Ports">
                         {{ containerport }} => <span class="label label-default" ng-repeat="(k,v) in hostports">{{ v.HostIp }}:{{ v.HostPort }}</span>
                     </li>
                 </ul>


### PR DESCRIPTION
I had a problem where the port bindings on my host weren't showing up.  

I saw that the container page is using HostConfig.PortBindings.   After checking the Network request for the container api, I saw that HostConfig.PortBindings returns a bunch of blanks, while the actual port bindings were shown in NetworkSettings.Ports.  I'm using Docker 1.9.1.


Relevant parts of the container api response:

```json
	"HostConfig": {
		"PortBindings": {
			"443/tcp": [{
				"HostIp": "",
				"HostPort": ""
			}],
			"80/tcp": [{
				"HostIp": "",
				"HostPort": ""
			}]
		}
    },
	"NetworkSettings": {
		"Ports": {
			"443/tcp": [{
				"HostIp": "0.0.0.0",
				"HostPort": "32825"
			}],
			"80/tcp": [{
				"HostIp": "0.0.0.0",
				"HostPort": "32826"
			}]
		}
    }
```