### PR TITLE
Fixed: Check if variable is plain object before using isEmptyObject()

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -133,7 +133,17 @@
 
         <tr>
             <td>Publish All:</td>
-            <td>{{ container.HostConfig.PublishAllPorts }}</td>
+            <td>
+            <div>{{ container.HostConfig.PublishAllPorts }}</div>
+            <div ng-show="container.HostConfig.PublishAllPorts">
+                <ul>
+                    <li ng-repeat="(containerport, hostports) in container.NetworkSettings.Ports">
+                        {{ containerport }} =>
+                        <span class="label label-default" style="margin-right: 5px;" ng-repeat="(k,v) in hostports">{{ v.HostIp }}:{{ v.HostPort }}</span>
+                    </li>
+                </ul>
+            </div>
+            </td>
         </tr>
         <tr>
             <td>Ports:</td>

--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -133,17 +133,7 @@
 
         <tr>
             <td>Publish All:</td>
-            <td>
-            <div>{{ container.HostConfig.PublishAllPorts }}</div>
-            <div ng-show="container.HostConfig.PublishAllPorts">
-                <ul>
-                    <li ng-repeat="(containerport, hostports) in container.NetworkSettings.Ports">
-                        {{ containerport }} =>
-                        <span class="label label-default" style="margin-right: 5px;" ng-repeat="(k,v) in hostports">{{ v.HostIp }}:{{ v.HostPort }}</span>
-                    </li>
-                </ul>
-            </div>
-            </td>
+            <td>{{ container.HostConfig.PublishAllPorts }}</td>
         </tr>
         <tr>
             <td>Ports:</td>

--- a/app/components/startContainer/startContainerController.js
+++ b/app/components/startContainer/startContainerController.js
@@ -40,7 +40,7 @@ angular.module('startContainer', ['ui.bootstrap'])
 
             function rmEmptyKeys(col) {
                 for (var key in col) {
-                    if (col[key] === null || col[key] === undefined || col[key] === '' || $.isEmptyObject(col[key]) || col[key].length === 0) {
+                    if (col[key] === null || col[key] === undefined || col[key] === '' || ($.isPlainObject(col[key]) && $.isEmptyObject(col[key])) || col[key].length === 0) {
                         delete col[key];
                     }
                 }


### PR DESCRIPTION
isEmptyObject() can only be used on plain objects (e.g. not on a boolean value such as PublishAllPorts). This can be fixed by checking isPlainObject() before using isEmptyObject().

This fixes not being able to use PublishAllPorts on Chrome (49).