### PR TITLE
Fixed: Show actual port bindings

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -141,7 +141,7 @@
                 <div ng-show="!editPorts">
                     <button class="btn btn-default btn-xs pull-right" ng-click="editPorts = true"><i class="glyphicon glyphicon-pencil"></i></button>
                     <ul>
-                    <li ng-repeat="(containerport, hostports) in container.HostConfig.PortBindings">
+                    <li ng-repeat="(containerport, hostports) in container.NetworkSettings.Ports">
                         {{ containerport }} =>
                         <span class="label label-default" style="margin-right: 5px;" ng-repeat="(k,v) in hostports">{{ v.HostIp }}:{{ v.HostPort }}</span>
                     </li>


### PR DESCRIPTION
The container.HostConfig.PortBindings is not always populated (e.g. when using PublishAllPorts).
The container.NetworkSettings.Ports does contain the actual port bindings.